### PR TITLE
Implement basic WebRTC pipeline

### DIFF
--- a/apps/capture/__init__.py
+++ b/apps/capture/__init__.py
@@ -1,0 +1,1 @@
+from .video import CameraCapture

--- a/apps/capture/video.py
+++ b/apps/capture/video.py
@@ -1,0 +1,17 @@
+import cv2
+
+class CameraCapture:
+    """Simple wrapper around cv2.VideoCapture"""
+
+    def __init__(self, device: int = 0):
+        self.cap = cv2.VideoCapture(device)
+
+    def read(self):
+        if not self.cap.isOpened():
+            return None
+        ret, frame = self.cap.read()
+        return frame if ret else None
+
+    def release(self):
+        if self.cap.isOpened():
+            self.cap.release()

--- a/apps/stylizer/__init__.py
+++ b/apps/stylizer/__init__.py
@@ -1,0 +1,1 @@
+from .cartoon import CartoonStylizer

--- a/apps/stylizer/cartoon.py
+++ b/apps/stylizer/cartoon.py
@@ -1,0 +1,5 @@
+class CartoonStylizer:
+    """Placeholder stylizer that returns frames unchanged."""
+
+    def stylize(self, frame):
+        return frame

--- a/tooncam/routing.py
+++ b/tooncam/routing.py
@@ -1,0 +1,6 @@
+from django.urls import path
+from tooncam.video.consumers import VideoConsumer
+
+websocket_urlpatterns = [
+    path('ws/video/', VideoConsumer.as_asgi()),
+]

--- a/tooncam/tooncam/asgi.py
+++ b/tooncam/tooncam/asgi.py
@@ -1,6 +1,14 @@
-"""ASGI config for tooncam project."""
+"""ASGI config for tooncam project with Channels support."""
 import os
 from django.core.asgi import get_asgi_application
+from channels.routing import ProtocolTypeRouter, URLRouter
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'tooncam.settings')
-application = get_asgi_application()
+django_asgi_app = get_asgi_application()
+
+import tooncam.routing
+
+application = ProtocolTypeRouter({
+    'http': django_asgi_app,
+    'websocket': URLRouter(tooncam.routing.websocket_urlpatterns),
+})

--- a/tooncam/tooncam/settings.py
+++ b/tooncam/tooncam/settings.py
@@ -17,6 +17,8 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'channels',
+    'tooncam.video',
 ]
 
 MIDDLEWARE = [
@@ -82,3 +84,9 @@ USE_TZ = True
 STATIC_URL = 'static/'
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+CHANNEL_LAYERS = {
+    'default': {
+        'BACKEND': 'channels.layers.InMemoryChannelLayer',
+    }
+}

--- a/tooncam/tooncam/urls.py
+++ b/tooncam/tooncam/urls.py
@@ -1,6 +1,7 @@
 from django.contrib import admin
-from django.urls import path
+from django.urls import path, include
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('', include('tooncam.video.urls')),
 ]

--- a/tooncam/video/__init__.py
+++ b/tooncam/video/__init__.py
@@ -1,0 +1,2 @@
+default_app_config = "tooncam.video.apps.VideoConfig"
+

--- a/tooncam/video/apps.py
+++ b/tooncam/video/apps.py
@@ -1,0 +1,5 @@
+from django.apps import AppConfig
+
+class VideoConfig(AppConfig):
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'tooncam.video'

--- a/tooncam/video/consumers.py
+++ b/tooncam/video/consumers.py
@@ -1,0 +1,54 @@
+from aiortc import RTCPeerConnection, RTCSessionDescription
+from aiortc.contrib.media import MediaBlackhole
+from channels.generic.websocket import AsyncWebsocketConsumer
+import json
+import asyncio
+from apps.capture.video import CameraCapture
+from apps.stylizer.cartoon import CartoonStylizer
+from aiortc import MediaStreamTrack
+from av import VideoFrame
+
+class CameraVideoTrack(MediaStreamTrack):
+    kind = "video"
+
+    def __init__(self, capture: CameraCapture, stylizer: CartoonStylizer):
+        super().__init__()
+        self.capture = capture
+        self.stylizer = stylizer
+
+    async def recv(self) -> VideoFrame:
+        loop = asyncio.get_event_loop()
+        frame = await loop.run_in_executor(None, self.capture.read)
+        if frame is None:
+            await asyncio.sleep(0.01)
+            return await self.recv()
+        frame = self.stylizer.stylize(frame)
+        video_frame = VideoFrame.from_ndarray(frame, format="bgr24")
+        video_frame.pts, video_frame.time_base = self.next_timestamp()
+        return video_frame
+
+class VideoConsumer(AsyncWebsocketConsumer):
+    async def connect(self):
+        await self.accept()
+        self.pc = RTCPeerConnection()
+        self.media = MediaBlackhole()
+        self.capture = CameraCapture()
+        self.stylizer = CartoonStylizer()
+
+    async def disconnect(self, close_code):
+        await self.pc.close()
+        self.capture.release()
+
+    async def receive(self, text_data=None, bytes_data=None):
+        data = json.loads(text_data)
+        if data.get("type") == "offer":
+            offer = RTCSessionDescription(sdp=data["sdp"], type=data["type"])
+            await self.pc.setRemoteDescription(offer)
+            self.pc.addTrack(CameraVideoTrack(self.capture, self.stylizer))
+            answer = await self.pc.createAnswer()
+            await self.pc.setLocalDescription(answer)
+            await self.send(json.dumps({
+                "sdp": self.pc.localDescription.sdp,
+                "type": self.pc.localDescription.type
+            }))
+

--- a/tooncam/video/templates/video/index.html
+++ b/tooncam/video/templates/video/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>ToonCam</title>
+</head>
+<body>
+  <video id="video" autoplay playsinline></video>
+  <script>
+    const ws = new WebSocket('ws://' + window.location.host + '/ws/video/');
+    let pc;
+
+    ws.onmessage = async (event) => {
+      const data = JSON.parse(event.data);
+      if (data.type === 'answer') {
+        await pc.setRemoteDescription(data);
+      }
+    };
+
+    ws.onopen = async () => {
+      pc = new RTCPeerConnection();
+      pc.ontrack = (ev) => {
+        document.getElementById('video').srcObject = ev.streams[0];
+      };
+      const offer = await pc.createOffer({offerToReceiveVideo: true});
+      await pc.setLocalDescription(offer);
+      ws.send(JSON.stringify(pc.localDescription));
+    };
+  </script>
+</body>
+</html>

--- a/tooncam/video/urls.py
+++ b/tooncam/video/urls.py
@@ -1,0 +1,6 @@
+from django.urls import path
+from .views import IndexView
+
+urlpatterns = [
+    path('', IndexView.as_view(), name='index'),
+]

--- a/tooncam/video/views.py
+++ b/tooncam/video/views.py
@@ -1,0 +1,4 @@
+from django.views.generic import TemplateView
+
+class IndexView(TemplateView):
+    template_name = 'video/index.html'


### PR DESCRIPTION
## Summary
- add OpenCV camera capture and simple stylizer
- create Channels consumer to answer WebRTC offers
- route websocket traffic via ASGI and Django
- provide minimal HTML page to view the stream

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python tooncam/manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6847a4994b20832490639711ee730e82