### PR TITLE
Add Docker setup with CPU/GPU Dockerfiles and compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ffmpeg libsm6 libxext6 \
+    && pip install --no-cache-dir -r requirements.txt \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY . .
+
+ENV PYTHONUNBUFFERED=1
+
+CMD ["python", "tooncam/manage.py", "runserver", "0.0.0.0:8000"]

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -1,0 +1,19 @@
+FROM nvidia/cuda:11.8.0-runtime-ubuntu22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        python3 python3-pip ffmpeg libsm6 libxext6 \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN python3 -m pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+ENV PYTHONUNBUFFERED=1
+
+CMD ["python3", "tooncam/manage.py", "runserver", "0.0.0.0:8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: "3.9"
+services:
+  django:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - .:/app
+    ports:
+      - "8000:8000"
+    depends_on:
+      - redis
+
+  redis:
+    image: redis:7
+    ports:
+      - "6379:6379"
+
+  nginx-rtmp:
+    image: alfg/nginx-rtmp
+    ports:
+      - "1935:1935"
+    profiles: ["rtmp"]


### PR DESCRIPTION
## Summary
- add Dockerfile for CPU-based Django container
- add Dockerfile.gpu for CUDA runtime
- provide docker-compose.yml for Django, Redis and optional Nginx RTMP

## Testing
- `python3 tooncam/manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Django)*

------
https://chatgpt.com/codex/tasks/task_e_6847a49885448324bff2048e54bc6fbc