### PR TITLE
Add basic video streaming pipeline

### DIFF
--- a/apps/capture/__init__.py
+++ b/apps/capture/__init__.py
@@ -1,0 +1,5 @@
+"""Video capture utilities."""
+
+from .camera import Camera
+
+__all__ = ["Camera"]

--- a/apps/capture/camera.py
+++ b/apps/capture/camera.py
@@ -1,0 +1,17 @@
+import cv2
+
+
+class Camera:
+    """Simple camera wrapper using OpenCV."""
+
+    def __init__(self, index: int = 0) -> None:
+        self.cap = cv2.VideoCapture(index)
+
+    def read(self):
+        ret, frame = self.cap.read()
+        if not ret:
+            return None
+        return frame
+
+    def release(self) -> None:
+        self.cap.release()

--- a/apps/output/__init__.py
+++ b/apps/output/__init__.py
@@ -1,0 +1,5 @@
+"""Output streaming views."""
+
+from .views import video_feed
+
+__all__ = ["video_feed"]

--- a/apps/output/views.py
+++ b/apps/output/views.py
@@ -1,0 +1,29 @@
+from django.http import StreamingHttpResponse
+
+from apps.capture import Camera
+from apps.stylizer import apply_style
+
+import cv2
+
+camera = Camera()
+
+def frame_generator():
+    """Yield JPEG frames wrapped for MJPEG streaming."""
+    while True:
+        frame = camera.read()
+        if frame is None:
+            break
+        frame = apply_style(frame)
+        ret, jpeg = cv2.imencode(".jpg", frame)
+        if not ret:
+            continue
+        yield (
+            b"--frame\r\nContent-Type: image/jpeg\r\n\r\n" + jpeg.tobytes() + b"\r\n"
+        )
+
+
+def video_feed(request):
+    return StreamingHttpResponse(
+        frame_generator(),
+        content_type="multipart/x-mixed-replace; boundary=frame",
+    )

--- a/apps/stylizer/__init__.py
+++ b/apps/stylizer/__init__.py
@@ -1,0 +1,5 @@
+"""Frame stylization utilities."""
+
+from .style import apply_style
+
+__all__ = ["apply_style"]

--- a/apps/stylizer/style.py
+++ b/apps/stylizer/style.py
@@ -1,0 +1,6 @@
+import cv2
+
+
+def apply_style(frame):
+    """Apply a simple cartoon-like effect using OpenCV."""
+    return cv2.stylization(frame, sigma_s=60, sigma_r=0.6)

--- a/tooncam/tooncam/settings.py
+++ b/tooncam/tooncam/settings.py
@@ -17,6 +17,9 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "apps.capture",
+    "apps.stylizer",
+    "apps.output",
 ]
 
 MIDDLEWARE = [

--- a/tooncam/tooncam/urls.py
+++ b/tooncam/tooncam/urls.py
@@ -1,6 +1,9 @@
 from django.contrib import admin
 from django.urls import path
 
+from apps.output import video_feed
+
 urlpatterns = [
     path("admin/", admin.site.urls),
+    path("video/", video_feed, name="video-feed"),
 ]


### PR DESCRIPTION
## Summary
- add simple camera wrapper
- implement basic frame stylizer using OpenCV
- provide MJPEG streaming view
- register new apps in Django settings and expose video feed route

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847a6f7a4b0832487511a66203e81b3